### PR TITLE
Feature/remove opensearch

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,15 +19,6 @@ services:
       - MARIADB_ROOT_PASSWORD=notsafeforproduction
     command:
       --lower_case_table_names=1
-  search:
-    image: opensearchproject/opensearch
-    ports:
-      - '127.0.0.1:9200:9200'
-      - '127.0.0.1:9300:9300' 
-    environment:
-      - discovery.type=single-node
-    volumes:
-      - ./search:/usr/share/opensearch/data
   phpmyadmin:
     image: phpmyadmin
     ports:


### PR DESCRIPTION
Remove Opensearch from the Docker configuration.  We don't need anything this extravagant and can use LIKE "%product-name%" queries