### PR TITLE
fixed OrderHistory from displaying all orders

### DIFF
--- a/docker/api/src/Application/Actions/User/UserOrderListAction.php
+++ b/docker/api/src/Application/Actions/User/UserOrderListAction.php
@@ -34,10 +34,10 @@ class UserOrderListAction extends Action
     /**
      * {@inheritdoc}
      */
-    protected function action(): \Psr\Http\Message\ResponseInterface 
+    protected function action(): Response
     {   
         $slug = $this->resolveArg('user_id');
-        $order = $this->em->getRepository(Order::class)->findAll();
+        $order = $this->em->getRepository(Order::class)->findBy(array('user_id' => $slug));
         return $this->respondWithData($order);
     }
 

--- a/src/Components/Card/Card.tsx
+++ b/src/Components/Card/Card.tsx
@@ -98,7 +98,11 @@ export function Card(props: Props) {
 
   }
   function addToFavorites() {
-    if (!isInFavorite && !loadingFav) {
+    if(userId == null){
+      setAlertMessage("You must be logged in")
+      setAlertVisible(true);
+    }
+    else if (!isInFavorite && !loadingFav) {
       setLoadingFav(true);
       let data: any = {};
       data["userId"] = userId;

--- a/src/Pages/CheckOutPage.tsx
+++ b/src/Pages/CheckOutPage.tsx
@@ -33,9 +33,9 @@ export function CheckOut() {
     }
 
     function onDeleteHandler(index: number) {
-        cartData.splice(index, 1)
-        setCartData([...cartData])
         let price = cartData[index].quantity * cartData[index].product.product_price;
+        cartData.splice(index, 1)
+        setCartData([...cartData])  
         setCartTotal(cartTotal - price);
     }
 

--- a/src/Pages/OrderHistory.tsx
+++ b/src/Pages/OrderHistory.tsx
@@ -10,8 +10,15 @@ import { $User } from "../Services/State";
 export function OrderHistory() {
     const [orders, setOrders] = useState<OrderType[]>([])
 
+    function getCookie() {
+        function escape(s:any) { return s.replace(/([.*+?\^$(){}|\[\]\/\\])/g, '\\$1'); }
+        var match = document.cookie.match(RegExp('(?:^|;\\s*)' + escape('freshMartUserId') + '=([^;]*)'));
+        return match ? match[1] : null;
+    }
+
     useEffect(() => {
-        fetch(process.env.REACT_APP_API_BASE + "/users/" + $User.value + "/orders").then(b => b.json()).then(data => setOrders(data.data))
+        let cookie = getCookie();
+        fetch(process.env.REACT_APP_API_BASE + "/users/" + cookie + "/orders").then(b => b.json()).then(data => setOrders(data.data))
     }, [])
 
     return (


### PR DESCRIPTION
- UserOrderListAction was returning all orders, now it is just returning orders related to user_id
- $User.value in fetch on OrderHistory.tsx page was not being set until after fetch was called resulting in null being passed in as user_id. Changed it to get the cookie before fetch.